### PR TITLE
Added the AGPLv3 and MPL-2.0 licenses

### DIFF
--- a/templates/_asset_fields.phtml
+++ b/templates/_asset_fields.phtml
@@ -127,8 +127,10 @@ $_asset_values = array_merge([
         <select id="license" name="cost" class="form-control">
             <?php $licenses = [
                 'MIT' => 'MIT',
+                'MPL-2.0' => 'MPL-2.0',
                 'GPLv3' => 'GPL v3',
                 'GPLv2' => 'GPL v2',
+                'AGPLv3' => 'AGPL v3',
                 'CC0' => 'CC0',
                 'BSD-2-Clause' => 'BSD 2-clause License',
                 'BSL-1.0' => 'Boost Software License'


### PR DESCRIPTION
Oh boy, I'm pretty much a fish out of water in relation to PHP, HTML, and such. So if I did something stupid, please tell.

As discussed in #133, I've added the MPL-2.0.

I've also added the AGPL v3. The reason being that the Godot Engine has a HTML5 exporter, and making your game web-only, it would be able to breach the default GPL via the ASP loophole (at least I think it's possible, if I'm completely mistaken, please inform me).

Fixes #133.