### PR TITLE
Use a modern font stack inspired by Bootstrap 4

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1,12 +1,18 @@
+body {
+    font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
 .form-search .form-group {
     margin-bottom: 0.2em;
     margin-right: 40px;
 }
+
 @media screen and (max-width: 768px) {
     .form-search .form-group {
         margin-right: 0;
     }
 }
+
 @supports (display: flex) {
     @media screen and (min-width: 768px) {
         .form-search {


### PR DESCRIPTION
Modern OSes ship with high-quality fonts that can be used out of the box with a simple change. It tends to be slightly more consistent across platforms too, even though it's still not perfect (especially on the Linux side of things).

See https://github.com/twbs/bootstrap/pull/19098 for more information.

### Screenshots

**Chromium 70 on Fedora 29:**

![assetlib_font_linux](https://user-images.githubusercontent.com/180032/50549691-feefcc00-0c61-11e9-96da-e75af86f9f88.png)

**Edge 17 on Windows 10:**

![assetlib_font_windows](https://user-images.githubusercontent.com/180032/50549693-ff886280-0c61-11e9-95af-b99c9f4208cf.png)

**Safari 11.1 on macOS 10.13:**

![assetlib_font_macos](https://user-images.githubusercontent.com/180032/50549692-feefcc00-0c61-11e9-9cd9-c8c038599baa.png)

(The author names were overridden because of my local database setup :smile:)