### PR TITLE
Updated footer to automatically set the copyright year

### DIFF
--- a/templates/_footer.phtml
+++ b/templates/_footer.phtml
@@ -3,7 +3,7 @@
                 <div class="col-md-12">
                     <hr/>
                     <p>
-                        Copyright &copy; 2018 The Godot Engine community - MIT licensed
+                        Copyright &copy; <?php echo date("Y"); ?> The Godot Engine community - MIT licensed
                         <?php if(file_exists('.git/HEAD')) { $HEAD_contents = file_get_contents('.git/HEAD');?>
                             <?php if(preg_match('/^ref: (.+)$/m', $HEAD_contents, $ref_matches)) {
                                 $ref = $ref_matches[1];

--- a/templates/_footer.phtml
+++ b/templates/_footer.phtml
@@ -3,7 +3,7 @@
                 <div class="col-md-12">
                     <hr/>
                     <p>
-                        Copyright &copy; <?php echo date("Y"); ?> The Godot Engine community - MIT licensed
+                        Copyright &copy; <?php echo esc(date("Y")); ?> The Godot Engine community - MIT licensed
                         <?php if(file_exists('.git/HEAD')) { $HEAD_contents = file_get_contents('.git/HEAD');?>
                             <?php if(preg_match('/^ref: (.+)$/m', $HEAD_contents, $ref_matches)) {
                                 $ref = $ref_matches[1];


### PR DESCRIPTION
The footer should now set the copyright year to the current year. Fixes  #172

PHP snippet from: [updateyourfooter.com](http://updateyourfooter.com/)