### PR TITLE
Use HTTPS for YouTube thumbnails

### DIFF
--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -199,8 +199,8 @@ $get_asset = function ($request, $response, $args) {
         if (!isset($previews[$i]['thumbnail']) || $previews[$i]['thumbnail'] == '') {
             if ($previews[$i]['type'] == 'video') {
                 $matches = [];
-                if (preg_match('|youtube.com/watch\\?v=([^&]+)|', $previews[$i]['link'], $matches)) {
-                    $previews[$i]['thumbnail'] = 'http://img.youtube.com/vi/'.$matches[1].'/default.jpg';
+                if (preg_match('|youtube\.com/watch\?v=([^&]+)|', $previews[$i]['link'], $matches)) {
+                    $previews[$i]['thumbnail'] = 'https://img.youtube.com/vi/'.$matches[1].'/default.jpg';
                 } else {
                     $previews[$i]['thumbnail'] = $previews[$i]['link'];
                 }


### PR DESCRIPTION
Helps a little with #127.

Also escape the `.` in the regex so it doesn't actually catch `youtube<anything>com`. :)