### PR TITLE
Replace occurences of $_SERVER['HTTP_HOST'] with Uri::getHost()

### DIFF
--- a/src/middleware.php
+++ b/src/middleware.php
@@ -146,7 +146,7 @@ if (FRONTEND) {
         if (isset($result['token'])) {
             $response = $this->cookies['responseCookies']->set($response, $this->cookies['setCookie']('token')
                 ->withValue($result['token'])
-                ->withDomain($_SERVER['HTTP_HOST'])
+                ->withDomain($request->getUri()->getHost())
                 ->withPath($request->getUri()->getBasePath())
                 ->withHttpOnly(true)
             );


### PR DESCRIPTION
I was running the asset library on `localhost:8000` and Firefox did just not set the `token` cookie at all, making login impossible. Turns out `$_SERVER['HTTP_HOST']` includes the port, while the `Domain` part in the `Set-Cookie` header should not. Using `$uri->getHost()` fixes this.

Other occurences where URL building happened were streamlined to only use `Uri` methods as well.