### PR TITLE
Add 4.0 version for assets

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -59,14 +59,13 @@ return $constants = [
         9999999 => 'custom_build'
     ]),
     'common_godot_versions' => [
-        // '1.0',
-        // '1.1',
         '2.0',
         '2.1',
         '2.2',
         '3.0',
         '3.1',
         '3.2',
+        '4.0',
         'unknown',
         'custom_build',
     ]


### PR DESCRIPTION
This allows uploading assets for the upcoming Godot 4.0 release.
I'd like to upload [InterpolatedCamera3D](https://github.com/Calinou/godot-interpolated-camera3d) to the asset library, but it only works with the `master` branch :slightly_smiling_face: 