### PR TITLE
Update Bootstrap and jQuery to the latest compatible versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "3",
-    "blueimp-file-upload": "jquery-file-upload#^9.12.3"
+    "bootstrap": "3.4.1",
+    "jquery": "3.5.1"
   }
 }

--- a/templates/_footer.phtml
+++ b/templates/_footer.phtml
@@ -33,9 +33,9 @@
     </div>
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script defer src="<?php echo raw($bowerpath) ?>/jquery/dist/jquery.slim.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="<?php echo raw($bowerpath) ?>/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script defer src="<?php echo raw($bowerpath) ?>/bootstrap/dist/js/bootstrap.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
jQuery 3.x works with Bootstrap 3.3.7 and above.

This also switches to the jQuery Slim version as we don't use the Ajax or Effects components from jQuery.