### PR TITLE
Display 40 items per page instead of 20

### DIFF
--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -10,7 +10,7 @@ $app->get('/asset', function ($request, $response, $args) {
     $username = '%';
     $order_column = 'modify_date';
     $support_levels = [];
-    $page_size = 20;
+    $page_size = 40;
     $max_page_size = 500;
     $page_offset = 0;
     $min_godot_version = 0;

--- a/src/routes/asset_edit.php
+++ b/src/routes/asset_edit.php
@@ -322,7 +322,7 @@ $app->get('/asset/edit', function ($request, $response, $args) {
     $filter = '%';
     $username = '%';
     $statuses = [];
-    $page_size = 20;
+    $page_size = 40;
     $max_page_size = 500;
     $page_offset = 0;
     if (isset($params['asset'])) {

--- a/templates/_pagination.phtml
+++ b/templates/_pagination.phtml
@@ -55,7 +55,7 @@
 </p>
 <p>
     Change items per page to: <span class="btn-group btn-group-xs" role="group" aria-label="Page size">
-        <?php foreach ([20, 50, 100, 200, 500] as $amount) { ?>
+        <?php foreach ([40, 100, 200, 500] as $amount) { ?>
             <a href="?<?php echo esc(http_build_query(['max_results' => $amount, 'page' => floor($data['page'] * $data['page_length'] / $amount)] + $params)) ?>" class="btn btn-default" aria-label="Per page">
                 <?php echo raw($amount); ?>
             </a>


### PR DESCRIPTION
Follow-up to #193.

This makes the asset library easier to browse by requiring less clicks to browse between pages (since there will be fewer pages overall).

The Godot editor is able to handle this change seamlessly.