### PR TITLE
Display "License" as the sort name instead of "Cost"

### DIFF
--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -48,7 +48,7 @@
             <select id="sort" name="sort" class="form-control">
                 <?php if(!isset($params['sort'])) $params['sort'] = 'updated'; foreach(['cost', 'name', 'updated'] as $id => $order) { ?>
                     <option value="<?php echo esc($order) ?>" <?php if(isset($params['sort']) && $order == $params['sort']) echo 'selected=""'; ?>>
-                        <?php echo ($order == 'cost' ) ?  "License" : esc(ucfirst($order)); ?>
+                        <?php echo $order === 'cost' ? "License" : esc(ucfirst($order)); ?>
                     </option>
                 <?php } ?>
             </select>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -48,7 +48,7 @@
             <select id="sort" name="sort" class="form-control">
                 <?php if(!isset($params['sort'])) $params['sort'] = 'updated'; foreach(['cost', 'name', 'updated'] as $id => $order) { ?>
                     <option value="<?php echo esc($order) ?>" <?php if(isset($params['sort']) && $order == $params['sort']) echo 'selected=""'; ?>>
-                        <?php echo $order === 'cost' ? "License" : esc(ucfirst($order)); ?>
+                        <?php echo $order === 'cost' ? "License" : esc(ucfirst($order)) ?>
                     </option>
                 <?php } ?>
             </select>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -48,7 +48,7 @@
             <select id="sort" name="sort" class="form-control">
                 <?php if(!isset($params['sort'])) $params['sort'] = 'updated'; foreach(['cost', 'name', 'updated'] as $id => $order) { ?>
                     <option value="<?php echo esc($order) ?>" <?php if(isset($params['sort']) && $order == $params['sort']) echo 'selected=""'; ?>>
-                        <?php echo esc(ucfirst($order)) ?>
+                        <?php echo ($order == 'cost' ) ?  "License" : esc(ucfirst($order)); ?>
                     </option>
                 <?php } ?>
             </select>


### PR DESCRIPTION
I made this (well, @sboronczyk made it) before I noticed #233 existed, but maybe this will be useful, possibly better...?

This is purely cosmetic change, it changes the text inside of the option, so it shouldn't affect the behavior at all.

Warning: I haven't tested this.