### PR TITLE
Trim leading/trailing whitespace from search queries

### DIFF
--- a/API.md
+++ b/API.md
@@ -170,8 +170,9 @@ Example response:
 Get a list of assets.
 
 Some notes:
+* Leading and trailing whitespace in `filter` is trimmed on the server side.
 * For legacy purposes, not supplying godot version would list only 2.1 assets, while not supplying type would list only addons.
-* To specify multiple support levels, join them with `+`, e.g. `support=official+community`
+* To specify multiple support levels, join them with `+`, e.g. `support=official+community`.
 * Godot version can be specified as you see fit, for example, `godot_version=3.1` or `godot_version=3.1.5`. Currently, the patch version is disregarded, but may be honored in the future.
 
 <div id="api-get-asset-id"></div>

--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -45,7 +45,7 @@ $app->get('/asset', function ($request, $response, $args) {
         }
     }
     if (isset($params['filter'])) {
-        $filter = '%'.preg_replace('/[[:punct:]]+/', '%', $params['filter']).'%';
+        $filter = '%'.preg_replace('/[[:punct:]]+/', '%', trim($params['filter'])).'%';
     }
     if (isset($params['user'])) {
         $username = $params['user'];

--- a/src/routes/asset_edit.php
+++ b/src/routes/asset_edit.php
@@ -344,7 +344,7 @@ $app->get('/asset/edit', function ($request, $response, $args) {
         }
     }
     if (isset($params['filter'])) {
-        $filter = '%'.preg_replace('/[[:punct:]]+/', '%', $params['filter']).'%';
+        $filter = '%'.preg_replace('/[[:punct:]]+/', '%', trim($params['filter'])).'%';
     }
     if (isset($params['user'])) {
         $username = $params['user'];


### PR DESCRIPTION
This means searching for `"interpolation "` or `" interpolation"` will now match assets containing `interpolation` in their name.

This affects both the web frontend and the REST API used by the Godot editor.

For reference, this is already done in the [asset library rewrite](https://github.com/Calinou/godot-asset-library-laravel).