### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ ___
 
 **Note:** This asset library backend and frontend is now in maintenance mode.
 Feel free to submit bug fixes and small improvements, but please refrain from
-working on large features. New development occurs in
-[godot-asset-library-laravel](https://github.com/Calinou/godot-asset-library-laravel)
-which will eventually be deployed as the official asset library.
+working on large features. In the future, the [Godot Foundation](https://godot.foundation/)'s asset store
+will deprecate this library.
 
 ___
 


### PR DESCRIPTION
Removed the redirect to the now-deprecated Laravel fork of the Asset Library , per https://github.com/Calinou/godot-asset-library-laravel/issues/467#issuecomment-1476949963