### PR TITLE
Changed rejection input to textarea

### DIFF
--- a/templates/asset_edit.phtml
+++ b/templates/asset_edit.phtml
@@ -201,7 +201,7 @@ $preview_field_names = [
                 <button type="submit" class="btn btn-danger">Reject</button>
                 <div class="form-group panel">
                     <label class="control-label" for="reason" required>Reason:</label>
-                    <input type="text" class="form-control" id="reason" name="reason">
+                    <textarea class="form-control" id="reason" name="reason"></textarea>
                 </div>
             </form>
         <?php } ?>


### PR DESCRIPTION
This makes submitting a rejection reason easier to see and edit when approving assets.  The very tiny input field doesn't quite work very well as is.

I was not able to fully test this change since I cannot get the site to function locally; though this change is so minor it should just work.