### PR TITLE
Display feed and edit history as table

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -158,7 +158,7 @@ footer {
     list-style: none;
 }
 
-.asset-list:not(.moderation-list) .asset-header {
+.asset-list .asset-header {
     flex: 1;
 }
 
@@ -216,6 +216,14 @@ footer {
     color: var(--base-color-text);
 }
 
+.table-tags .label {
+    display: block;
+    width: 100%;
+    padding: 0;
+    font-size: 14px;
+    text-align: center;
+}
+
 .asset-tags .label {
     padding: 0 6px;
     font-size: 13px;
@@ -227,10 +235,6 @@ footer {
     align-items: center;
     flex: 1;
     gap: 6px;
-}
-
-.asset-tags-moderation {
-    justify-content: flex-end;
 }
 
 .asset-tags {
@@ -472,5 +476,23 @@ footer {
     .asset-header,
     .asset-footer {
         border-color: var(--primary-background-color)
+    }
+    
+    .table-bordered {
+        border: 2px solid var(--secondary-background-color);
+    }
+
+    .table-bordered > thead > tr > th,
+    .table-bordered > tbody > tr > td,
+    .table-bordered > tbody > tr > th {
+        border: none;
+    }
+
+    .table-bordered thead {
+        border-bottom: 2px solid var(--default-background-color);
+    }
+
+    .table-striped > tbody > tr:nth-of-type(2n+1) {
+        background-color: var(--secondary-background-color);
     }
 }

--- a/src/queries.php
+++ b/src/queries.php
@@ -13,7 +13,7 @@ return [
         'register' => 'INSERT INTO `as_users` SET username = :username, email = :email, password_hash = :password_hash',
         'promote' => 'UPDATE `as_users` SET type = :type WHERE user_id = :id AND type < :type',
         // 'demote' => 'UPDATE `as_users` SET type = :type WHERE user_id = :id AND type > :type',
-        'list_edit_events' => 'SELECT edit_id, asset_id, COALESCE(`as_asset_edits`.title, `as_assets`.title) AS title, category, COALESCE(`as_asset_edits`.version_string, `as_assets`.version_string) AS version_string, COALESCE(`as_asset_edits`.icon_url, `as_assets`.icon_url) AS icon_url, status, reason FROM `as_asset_edits`
+        'list_edit_events' => 'SELECT edit_id, asset_id, COALESCE(`as_asset_edits`.title, `as_assets`.title) AS title, `as_asset_edits`.submit_date, `as_asset_edits`.modify_date, category, COALESCE(`as_asset_edits`.version_string, `as_assets`.version_string) AS version_string, COALESCE(`as_asset_edits`.icon_url, `as_assets`.icon_url) AS icon_url, status, reason FROM `as_asset_edits`
             LEFT JOIN `as_assets` USING (asset_id)
             LEFT JOIN `as_categories` ON `as_categories`.category_id = COALESCE(`as_asset_edits`.category_id, `as_assets`.category_id)
             WHERE `as_asset_edits`.user_id = :user_id
@@ -126,6 +126,8 @@ return [
 
         'search' => 'SELECT edit_id, asset_id,
         `as_asset_edits`.user_id,
+        `as_asset_edits`.submit_date,
+        `as_asset_edits`.modify_date,
         COALESCE(`as_asset_edits`.title, `as_assets`.title) AS title,
         COALESCE(`as_asset_edits`.description, `as_assets`.description) AS description,
         COALESCE(`as_asset_edits`.godot_version, `as_assets`.godot_version) AS godot_version,

--- a/templates/_header.phtml
+++ b/templates/_header.phtml
@@ -25,7 +25,7 @@
 
     <!-- Bootstrap -->
     <link href="<?php echo raw($basepath) ?>/assets/css/bootstrap-3.4.1.min.css" rel="stylesheet">
-    <link href="<?php echo raw($basepath) ?>/assets/css/base.css?5" rel="stylesheet">
+    <link href="<?php echo raw($basepath) ?>/assets/css/base.css?6" rel="stylesheet">
 </head>
 
 <body>

--- a/templates/asset_edits.phtml
+++ b/templates/asset_edits.phtml
@@ -50,47 +50,34 @@
     </form>
 
     <div class="asset-search-results">
-        <ol class="asset-list moderation-list">
-            <?php foreach($data['result'] as $i => $asset_edit) { ?>
-                <li class="asset-item">
-                    <a href="<?php echo raw($basepath) . '/asset/edit/' . url($asset_edit['edit_id']) ?>" class="asset-header">
-                        <img class="media-object" src="<?php echo esc($asset_edit['icon_url']) ?>" alt="<?php echo esc($asset_edit['title']) ?>'s icon" width=80 height=80>
-                        <div class="asset-title">
-                            <h4><?php echo esc($asset_edit['title']) ?></h4>
-                            <div class="asset-tags-container">
-                                <div class="asset-tags">
-                                    <span class="label label-info"><?php echo raw(ucfirst(str_replace('_', ' ', $asset_edit['godot_version']))) ?></span>
-                                    <span class="label label-<?php echo raw([
-                                        'official' => 'danger',
-                                        'community' => 'success',
-                                        'testing' => 'default',
-                                    ][$asset_edit['support_level']]) ?>"><?php echo raw(ucfirst($asset_edit['support_level'])) ?></span>
-                                </div>
-                            </div>
-                            <div class="asset-tags-container asset-tags-moderation">
-                                <div class="asset-tags">
-                                    <span class="label label-default"><?php echo raw($asset_edit['author']) ?></span>
-                                    <span class="label label-<?php echo raw([
-                                        'new' => 'info',
-                                        'in_review' => 'primary',
-                                        'rejected' => 'danger',
-                                        'accepted' => 'success'
-                                    ][$asset_edit['status']]) ?>"><?php echo raw(ucfirst(str_replace('_', ' ', $asset_edit['status']))) ?></span>
-                                </div>
-                            </div>
-                        </div>
-                    </a>
-                    <?php if($asset_edit['status'] == 'rejected' && $asset_edit['reason']) { ?>
-                        <div class="asset-footer">
-                            <div>
-                                <span><b>Rejection reason:</b></span><br>
-                                <span><?php echo esc($asset_edit['reason']) ?></span>
-                            </div>
-                        </div>
-                    <?php } ?>
-                </li>
-            <?php } ?>
-        </ol>
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th scope="col">Status</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Asset Name</th>
+                    <th scope="col">Submit Date</th>
+                    <th scope="col">Revision Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach($data['result'] as $i => $asset_edit) { ?>
+                    <?php $submit_date = new DateTime($asset_edit['submit_date']); $modify_date = new DateTime($asset_edit['modify_date']); ?>
+                    <tr>
+                        <td class="table-tags">
+                            <span class="label label-<?php
+                            echo raw(['new' => 'info', 'in_review' => 'primary', 'rejected' => 'danger', 'accepted' => 'success'][$asset_edit['status']]) ?>">
+                                <?php echo raw(ucfirst(str_replace('_', ' ', $asset_edit['status']))) ?>
+                            </span>
+                        </td>
+                        <td><?php echo ($asset_edit['asset_id'] == -1 ? 'Create ' : 'Edit ') ?></td>
+                        <td><a href="<?php echo raw($basepath) . '/asset/edit/' . url($asset_edit['edit_id']) ?>"><?php echo esc($asset_edit['title']) ?></a></td>
+                        <td><?php echo raw($submit_date->format("Y-m-d")) ?></td>
+                        <td><?php echo ($asset_edit['status'] === 'new') ? 'Pending' : raw($modify_date->format("Y-m-d")) ?></td>
+                    </tr>
+                <?php } ?>
+            </tbody>
+        </table>
 
         <?php include("_pagination.phtml") ?>
     </div>

--- a/templates/feed.phtml
+++ b/templates/feed.phtml
@@ -1,25 +1,29 @@
 <?php include("_header.phtml") ?>
-<?php foreach($data['events'] as $i => $event) { ?>
-    <div class="media"> <!-- TODO: Get real feed from @alketii -->
-        <div class="media-left">
-
-            <i class="glyphicon glyphicon-<?php echo raw([
-                'new' => 'unchecked text-default',
-                'in_review' => 'check text-primary',
-                'rejected' => 'remove text-danger',
-                'accepted' => 'ok text-success'][$event['status']])
-            ?>" style="font-size:30px"></i>
-        </div>
-        <div class="media-body">
-            <h4 class="media-heading">
-                <span><?php echo ($event['asset_id'] == -1 ? 'Create ' : 'Edit ') ?></span>
-                <a href="<?php echo raw($basepath) . '/asset/edit/' . url($event['edit_id']) ?>">"<?php echo esc($event['title']) ?>"</a>
-                <span class="label label-<?php
-                echo raw(['new' => 'info', 'in_review' => 'primary', 'rejected' => 'danger', 'accepted' => 'success'][$event['status']])
-                ?>"><?php echo raw(ucfirst(str_replace('_', ' ', $event['status']))) ?></span>
-            </h4>
-            <?php if($event['reason']) echo 'Reason: ' . esc($event['reason']) ?>
-        </div>
-    </div>
-<?php } ?>
+<table class="table table-striped table-bordered">
+    <thead>
+        <tr>
+            <th scope="col">Status</th>
+            <th scope="col">Type</th>
+            <th scope="col">Asset Name</th>
+            <th scope="col">Submit Date</th>
+            <th scope="col">Revision Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach($data['events'] as $i => $event) { ?>
+            <tr>
+                <td class="table-tags">
+                    <span class="label label-<?php
+                    echo raw(['new' => 'info', 'in_review' => 'primary', 'rejected' => 'danger', 'accepted' => 'success'][$event['status']]) ?>">
+                        <?php echo raw(ucfirst(str_replace('_', ' ', $event['status']))) ?>
+                    </span>
+                </td>
+                <td><?php echo ($event['asset_id'] == -1 ? 'Create ' : 'Edit ') ?></td>
+                <td><a href="<?php echo raw($basepath) . '/asset/edit/' . url($event['edit_id']) ?>"><?php echo esc($event['title']) ?></a></td>
+                <td><?php echo raw($event['submit_date']) ?></td>
+                <td><?php echo ($event['status'] === 'new') ? 'Pending' : raw($event['modify_date']) ?></td>
+            </tr>
+        <?php } ?>
+    </tbody>
+</table>
 <?php include("_footer.phtml") ?>


### PR DESCRIPTION
The edit history table only shows the date, not the time, because it is publicly available.
The feed table includes the time, because it is user bound.

(the light theme is the normal 3.4 bootstrap table with striped and bordered)

Feed:
![feed_table](https://github.com/godotengine/godot-asset-library/assets/48352564/c09d33d5-429d-4e30-b984-45a15e1b2e02)

Edit History:
![edit_history_table](https://github.com/godotengine/godot-asset-library/assets/48352564/368b49ba-feb1-4ad5-9e4a-38635421ace1)
