### PR TITLE
Add ISC license and change wording on adding new licenses

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -92,6 +92,7 @@ return $constants = [
         'BSD-2-Clause' => 'BSD 2-clause License',
         'BSD-3-Clause' => 'BSD 3-clause License',
         'BSL-1.0' => 'Boost Software License',
+        'ISC' => 'ISC License',
         'Unlicense' => 'The Unlicense License'
     ]
 ];

--- a/templates/_asset_fields.phtml
+++ b/templates/_asset_fields.phtml
@@ -71,7 +71,7 @@ $_asset_values = array_merge([
                 </option>
             <?php } ?>
         </select>
-        <span class="help-block">The license under which the asset is available. Check <a href="https://opensource.org/licenses">opensource.org</a> for a more detailed description of each. In case an OSI-approved license you are using is missing, you might <a href="https://github.com/godotengine/asset-library/issues">open an issue</a> about it.</span>
+        <span class="help-block">The license under which the asset is available. Check <a href="https://opensource.org/licenses">opensource.org</a> for a more detailed description of each. In case an OSI-approved license you are using is missing, please add the license in <a href="https://github.com/godotengine/godot-asset-library/blob/master/src/constants.php">this file</a> and open a pull request.</span>
         <span class="help-block"><strong>Note:</strong> The license you specify here should also be included in the repository you are submitting under a standard name, such as LICENSE or LICENSE.md</span>
     </div>
 </div>


### PR DESCRIPTION
Add the ISC license as an option: [OSI](https://opensource.org/license/isc-license-txt/), [Wikipedia](https://en.wikipedia.org/wiki/ISC_license). This is a functionally equivalent (but less wordy) MIT license.

Adding licenses is a trivial change (unless I've missed something!), so have also amended the text to point to the `src/constants.php` such that it can be directly PR'd in future additions without an issue. 

Fixes #295.