### PR TITLE
Possible fix to asset approval failure

### DIFF
--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -156,7 +156,7 @@ $app->get('/asset', function ($request, $response, $args) {
         'pages' => ceil($total_count / $page_size),
         'page_length' => $page_size,
         'total_items' => (int) $total_count,
-    ], 200);
+    ], 200, JSON_PARTIAL_OUTPUT_ON_ERROR);
 });
 
 // Get information for a single asset


### PR DESCRIPTION
This asset approval bug has been around for a while.  Yuri made some minor database changes that fixed it for certain assets but there are still assets trapped behind the generic `Error: An error occured while executing DB queries` error.  Some have been sitting for a few months.

I asked Emi to try to approve one then send me a snippet of the log file where the error exists since this has been so pervasive.  Based on that, I'm guessing this may have something to do with it: `Slim Application Error: Type: RuntimeException Code: 7 Message: Inf and NaN cannot be JSON encoded`. So this pull-request may fix that or may not and, at the last, maybe leads someone with better access to an actual fix.