### PR TITLE
Revert JSON flag, added actual error messages to DB calls

### DIFF
--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -156,7 +156,7 @@ $app->get('/asset', function ($request, $response, $args) {
         'pages' => ceil($total_count / $page_size),
         'page_length' => $page_size,
         'total_items' => (int) $total_count,
-    ], 200, JSON_PARTIAL_OUTPUT_ON_ERROR);
+    ], 200);
 });
 
 // Get information for a single asset

--- a/src/routes/asset_edit.php
+++ b/src/routes/asset_edit.php
@@ -700,7 +700,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
     $query_edit->bindValue(':edit_id', (int) $args['id'], PDO::PARAM_INT);
     $query_edit->execute();
 
-    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_edit);
+    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_edit, 'Cannot get asset edit data from database.');
     $error = $this->utils->errorResponseIfQueryNoResults($error, $response, $query_edit);
     if ($error) {
         return $response;
@@ -755,7 +755,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
     $query_status->bindValue(':reason', '');
 
     $query_status->execute();
-    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_status);
+    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_status, 'Unable to update asset status in database');
     $error = $this->utils->errorResponseIfQueryNoResults(false, $response, $query_status); // Important: Ensure that something was actually changed
     if ($error) {
         $this->db->rollback();
@@ -764,7 +764,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
 
     // Run
     $query->execute();
-    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query);
+    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query, 'Failed query build process');
     if ($error) {
         $this->db->rollback();
         return $response;
@@ -781,7 +781,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
 
         $query_update_id->execute();
 
-        $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_update_id);
+        $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_update_id, 'Failed to update the newly-created asset ID');
         if ($error) {
             $this->db->rollback();
             return $response;
@@ -815,7 +815,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
         }
 
         $query_apply_preview->execute();
-        $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_apply_preview);
+        $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_apply_preview, 'Failed to apply preview data for asset');
         if ($error) {
             $this->db->rollback();
             return $response;
@@ -829,7 +829,7 @@ $app->post('/asset/edit/{id:[0-9]+}/accept', function ($request, $response, $arg
     $query_verify->bindValue(':type', (int) $this->constants['user_type']['verified'], PDO::PARAM_INT);
 
     $query_verify->execute();
-    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_verify);
+    $error = $this->utils->errorResponseIfQueryBad(false, $response, $query_verify, 'Failed to mark user as verified');
     if ($error) {
         $this->db->rollback();
         return $response;


### PR DESCRIPTION
This PR will revert the change from the previous one; though I don't think it would hurt anything.  This also adds more specific error messages to `errorResponseIfQueryBad` as it currently returns the same message for six different instances which doesn't help differentiate where the error happens.

I originally assumed PHP was providing some kind of log entry for this error but it does not seem to based on what Emi found; makes this significantly harder to track down without specific message for each instance.