### PR TITLE
Rename Official support level to Featured in the frontend

### DIFF
--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -116,7 +116,7 @@
                                         'official' => 'danger',
                                         'community' => 'success',
                                         'testing' => 'default',
-                                    ][$asset['support_level']]) ?>"><?php echo esc(ucfirst($asset['support_level'])) ?></span>
+                                    ][$asset['support_level']]) ?>"><?php echo esc(str_replace('Official', 'Featured', ucfirst($asset['support_level']))) ?></span>
                                 </div>
                                 <div class="asset-tags">
                                     <span class="label label-default"><?php echo esc($asset['cost']) ?></span>


### PR DESCRIPTION
- Companion PR to https://github.com/godotengine/godot/pull/89987.

This paves the way for integrating hand-picked high-quality assets to be displayed in the project manager when accepting the "you don't have any projects yet" dialog.

The backend name remains identical to ensure backwards compatibility in the API.
