### PR TITLE
Added featured tag to support levels

### DIFF
--- a/API.md
+++ b/API.md
@@ -130,7 +130,7 @@ Get a list of categories (needed for filtering assets) and potentially a login U
 ```http
 ?type=(any|addon|project)
 &category=(category id)
-&support=(official|community|testing)
+&support=(official|featured|community|testing)
 &filter=(search text)
 &user=(submitter username)
 &cost=(license)
@@ -173,7 +173,7 @@ Get a list of assets.
 Some notes:
 * Leading and trailing whitespace in `filter` is trimmed on the server side.
 * For legacy purposes, not supplying godot version would list only 2.1 assets, while not supplying type would list only addons.
-* To specify multiple support levels, join them with `+`, e.g. `support=official+community`.
+* To specify multiple support levels, join them with `+`, e.g. `support=featured+community`.
 * Godot version can be specified as you see fit, for example, `godot_version=3.1` or `godot_version=3.1.5`. Currently, the patch version is disregarded, but may be honored in the future.
 
 <div id="api-get-asset-id"></div>
@@ -267,7 +267,7 @@ Revert a deletion of an asset. Useable by moderators and the owner of the asset.
 ### `POST /asset/{id}/support_level`
 ```json
 {
-  "support_level": "official|community|testing",
+  "support_level": "official|featured|community|testing",
   "token": "…"
 }
 ```

--- a/src/constants.php
+++ b/src/constants.php
@@ -30,6 +30,7 @@ return $constants = [
         'testing' => 0,
         'community' => 1,
         'official' => 2,
+        'featured' => 2,
     ]),
     'user_type' => double_map([
         'normal' => 0,

--- a/src/routes/asset.php
+++ b/src/routes/asset.php
@@ -99,7 +99,7 @@ $app->get('/asset', function ($request, $response, $args) {
     }
 
     if (count($support_levels) === 0) {
-        $support_levels = [0, 1, 2]; // Testing + Community + Official
+        $support_levels = [0, 1, 2]; // Testing + Community + Official / Featured
     }
     $support_levels = implode('|', $support_levels);
 

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -18,6 +18,7 @@
             <span class="label label-info"><?php echo esc(ucfirst(str_replace('_', ' ', $data['godot_version']))) ?></span>
             <span class="label label-<?php echo raw([
                 'official' => 'danger',
+                'featured' => 'danger',
                 'community' => 'success',
                 'testing' => 'default',
             ][$data['support_level']]) ?>"><?php echo esc(ucfirst($data['support_level'])) ?></span>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -114,6 +114,7 @@
                                     <span class="label label-info"><?php echo esc(ucfirst(str_replace('_', ' ', $asset['godot_version']))) ?></span>
                                     <span class="label label-<?php echo raw([
                                         'official' => 'danger',
+                                        'featured' => 'danger',
                                         'community' => 'success',
                                         'testing' => 'default',
                                     ][$asset['support_level']]) ?>"><?php echo esc(ucfirst($asset['support_level'])) ?></span>


### PR DESCRIPTION
- *Production edit: Alternative to https://github.com/godotengine/godot-asset-library/pull/322.*

This adds the featured tag in and keeps the official tag as well. In constants, the featured key should map to 2, which is what official was. I didn't get my Apache settings sorted properly but the local version showed featured in there when I was looking at my copy.  Not 100% sure this works in production but should be easy enough to tweak... right?

Also, hopefully, this is what you wanted.