### PR TITLE
Allow assets with proprietary licenses

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -94,6 +94,7 @@ return $constants = [
         'BSD-3-Clause' => 'BSD 3-clause License',
         'BSL-1.0' => 'Boost Software License',
         'ISC' => 'ISC License',
-        'Unlicense' => 'The Unlicense License'
+        'Unlicense' => 'The Unlicense License',
+        'Proprietary' => 'Proprietary (see LICENSE file)',
     ]
 ];


### PR DESCRIPTION
Currently, assets on the asset library can only select from a list of Open Source licenses:

![Selection_134](https://github.com/godotengine/godot-asset-library/assets/191561/bfeb3dfe-3ee4-4b5e-a788-e719a8604da3)

This PR adds a new option: **"Proprietary (see LICENSE file)"**

This can allow assets with proprietary licenses, where they put the details of the license into a `LICENSE` or `LICENSE.txt` or `LICENSE.md` or whatever.

I did my best to test it locally and it seems to be working, but this is my first time messing around with the asset library code, so hopefully there isn't any more that needs to be done.