### PR TITLE
Add EUPL-1.2 to licenses list

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -85,6 +85,7 @@ return $constants = [
         'LGPLv2.1' => 'LGPL v2.1',
         'LGPLv2' => 'LGPL v2',
         'AGPLv3' => 'AGPL v3',
+        'EUPL-1.2' => 'European Union Public License 1.2',
         'Apache-2.0' => 'Apache 2.0',
         'CC0' => 'CC0 1.0 Universal',
         'CC-BY-4.0' => 'CC BY 4.0 International',


### PR DESCRIPTION
Just adding another license.

I took the short and long names from [SPDX](https://spdx.org/licenses/preview/EUPL-1.2.html)

I was unsure of where to add it in the list, since putting it at the end next to proprietary licenses doesn't feel right.
I ended up putting it right after the other copyleft software licenses, since EUPL is also a software-focused copyleft license, and since it is explicitly compatible with the GNU copyleft licenses.

I hope that makes sense.