### PR TITLE
Add ZPL-2.1 (Zope Public License 2.1) to license list

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -98,5 +98,6 @@ return $constants = [
         'ISC' => 'ISC License',
         'Unlicense' => 'The Unlicense License',
         'Proprietary' => 'Proprietary (see LICENSE file)',
+        'ZPL-2.1' => 'Zope Public License 2.1',
     ]
 ];


### PR DESCRIPTION
I recently started doing more research into licenses for my projects, and came across the ZPL-2.1.

I have an addon I recently started working on (https://gitlab.com/ShadowFungi/SFInputRemapper), which I want to license under the ZPL-2.1 and there is not an option for it yet.

I've read a few of the recent pull requests that wanted to add a license, and noticed that you don't want to bloat the list too much, but I would greatly appreciate it if this is was merged as I could get.

> After chatting with the user I think we should add the license, but in the future I think it might be better to have a text-field instead of a dropdown for this 😅

_Originally posted by @coppolaemilio in https://github.com/godotengine/godot-asset-library/issues/327#issuecomment-2120128547_

However if you don't want to merge this I would greatly appreciate being pointed towards where the dropdown is implemented, so I can add an "other/non-listed license" that allows one to type one into a text field.

Lastly if you are not open to either of these, I will consider switching to the MPL-2.0, and thank you for any consideration, or advice.